### PR TITLE
11.2 Método cerrarConexiones() (Video 2) - Gabriel

### DIFF
--- a/Python/Semana13/Leccion07/capa_datos_persona/conexion.py
+++ b/Python/Semana13/Leccion07/capa_datos_persona/conexion.py
@@ -67,7 +67,7 @@ class Conexion:
 
 if __name__ == '__main__':
     conexion1 = Conexion.obtenerConexion()
-    Conexion.liberarConexion(conexion1) # Obtiene la conexión y la libera, mientras haya tras conexiones activas termina de ser ocupada y se libera mientras otras pueden estar conctadas lal mismo tiempo y al liberarse puede ser ocupada por otro usuario
+    Conexion.liberarConexion(conexion1) # Obtiene la conexión y la libera, mientras haya tras conexiones activas termina de ser ocupada, otras pueden estar conctadas al mismo tiempo.
     conexion2 = Conexion.obtenerConexion()
     Conexion.liberarConexion(conexion2)
     conexion3 = Conexion.obtenerConexion()

--- a/Python/Semana13/Leccion07/capa_datos_persona/conexion.py
+++ b/Python/Semana13/Leccion07/capa_datos_persona/conexion.py
@@ -54,6 +54,12 @@ class Conexion:
     def liberarConexion(cls, conexion):
         cls.obtenerPool().putconn(conexion)
         log.debug(f'Regresamos la conexion del pool: {conexion}')
+
+    # 11.2 MétodocerrarConexiones()(Video2)
+    # Creamos un método para cerrar por completo el método pool de conexiones
+    @classmethod
+    def cerrarConexiones(cls):
+        cls.obtenerPool().closeall()
         
 
 
@@ -61,8 +67,11 @@ class Conexion:
 
 if __name__ == '__main__':
     conexion1 = Conexion.obtenerConexion()
+    Conexion.liberarConexion(conexion1) # Obtiene la conexión y la libera, mientras haya tras conexiones activas termina de ser ocupada y se libera mientras otras pueden estar conctadas lal mismo tiempo y al liberarse puede ser ocupada por otro usuario
     conexion2 = Conexion.obtenerConexion()
+    Conexion.liberarConexion(conexion2)
     conexion3 = Conexion.obtenerConexion()
+    Conexion.liberarConexion(conexion3)
     conexion4 = Conexion.obtenerConexion()
     conexion5 = Conexion.obtenerConexion()
 


### PR DESCRIPTION
Actualizo:

Python/Semana13/Leccion07/capa_datos_persona/
conexion.py

Responsabilidades:
-Creamos un método para cerrar por completo el método pool de conexiones. Liberamos y volvemos a utilizar las conexiones.